### PR TITLE
Added support for toybox.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # pdParticles
-pdParticles is a free Playdate particle library created by [PossiblyAxolotl](https://www.youtube.com/PossiblyAxolotl).
 
+[![Lua Version](https://img.shields.io/badge/Lua-5.4-yellowgreen)](https://lua.org) [![Toybox Compatible](https://img.shields.io/badge/toybox.py-compatible-brightgreen)](https://toyboxpy.io) [![Latest Version](https://img.shields.io/github/v/tag/PossiblyAxolotl/pdParticles)](https://github.com/PossiblyAxolotl/pdParticles/tags)
+
+pdParticles is a free Playdate particle library created by [PossiblyAxolotl](https://www.youtube.com/PossiblyAxolotl).
 
 ![playdate-20230131-144652](https://user-images.githubusercontent.com/76883695/215882419-0d358b40-1236-477b-a207-c5ba053922fd.gif)
 
@@ -13,5 +15,22 @@ You can use pdParticles to draw circles, basic shapes, and custom sprites.
 ![playdate-20230201-183243](https://user-images.githubusercontent.com/76883695/216210932-96f53f97-a7ac-477d-9776-eb9704093f89.gif)
 
 Check out the [wiki](https://github.com/PossiblyAxolotl/pdParticles/wiki) to see how to get started and use the library. 
+
+#### Installing using toybox.py
+
+You can add it to your **Playdate** project by installing [**toybox.py**](https://toyboxpy.io), going to your project folder in a Terminal window and typing:
+
+```console
+toybox add pdParticles
+toybox update
+```
+
+Then, if your code is in the `source` folder, just import the following:
+
+```lua
+import '../toyboxes/toyboxes.lua'
+```
+
+#### Donating
 
 And if you're interested in donating to me you can do so on my [itch.io](https://possiblyaxolotl.itch.io/pdparticles).


### PR DESCRIPTION
This just required adding the library to the toystore so the only thing here is updating the readme to inform people how to use the library via toybox.py.

The sample code could also be made to use toy box instead of duplicating the pdParticles.lua file multiple times but I'll leave that to you if you want to do this.

Nice library!