### PR TITLE
Cleanup particle parts immediately

### DIFF
--- a/pdParticles.lua
+++ b/pdParticles.lua
@@ -172,11 +172,10 @@ local function decay(partlist, decay)
         partlist[part] = particle
     end
 
-    for part = 1, #partlist, 1 do
+    for part = #partlist, 1, -1 do
         local particle = partlist[part]
         if particle.size <= 0 then
             table.remove(partlist,part)
-            break
         end
     end
 
@@ -188,11 +187,10 @@ local function disappear(partlist)
         local particle = partlist[part]
         particle.lifespan -= .1
     end
-    for part = 1, #partlist, 1 do
+    for part = #partlist, 1, -1 do
         local particle = partlist[part]
         if particle.lifespan <= 0 then
             table.remove(partlist,part)
-            break
         end
     end
 
@@ -217,12 +215,12 @@ end
 local function stay(partlist, bounds)
     if bounds[3] > bounds[1] and bounds[4] > bounds[2] then
         local xDif , yDif = bounds[3] - bounds[1], bounds[4] - bounds[2]
-        for part = 1, #partlist, 1 do
+        for part = #partlist, 1, -1 do
             local particle = partlist[part]
-            if particle.x > bounds[3] then table.remove(partlist,part) break
-            elseif particle.x < bounds[1] then table.remove(partlist,part) break
-            elseif particle.y > bounds[4] then table.remove(partlist,part) break
-            elseif particle.y < bounds[2] then table.remove(partlist,part) break end
+            if particle.x > bounds[3] then table.remove(partlist,part)
+            elseif particle.x < bounds[1] then table.remove(partlist,part)
+            elseif particle.y > bounds[4] then table.remove(partlist,part)
+            elseif particle.y < bounds[2] then table.remove(partlist,part) end
         end
     end
 


### PR DESCRIPTION
Somewhat related to #4, I still experienced issues with spawning a large amount of particles. I traced the issue to the `break` statements in the cleanup loop for individual parts within a particle:

https://github.com/PossiblyAxolotl/pdParticles/blob/5e89ebbdd5eb6c490d73a55e0a2415f59ab894a2/pdParticles.lua#L175-L181

I'm not sure if these were placed here for performance reasons, but it does create an issue when doing something like this:

```lua
local thruster = ParticleCircle(200, 120)
function playdate.update()
    thruster:add(5)
    Particles.update()
end
```

When you continuously call `:add` with any value bigger than `1`, the list of parts grows faster than it is pruned. You can quickly see this from the simulator's Malloc Log (or the FPS drop on device).

Submitted a PR with a fix for this in case the "deferred cleanup" behaviour was not intended :)