### PR TITLE
Eliminate unnecessary 3rd argument to playdate.graphics.drawPixel

### DIFF
--- a/pdParticles.lua
+++ b/pdParticles.lua
@@ -569,7 +569,7 @@ function ParticlePixel:update()
     for part = 1, #self.particles, 1 do
         local pix = self.particles[part]
         
-        playdate.graphics.drawPixel(pix.x,pix.y,pix.size)
+        playdate.graphics.drawPixel(pix.x,pix.y)
 
         pix.x += math.sin(math.rad(pix.dir)) * pix.speed
         pix.y -= math.cos(math.rad(pix.dir)) * pix.speed


### PR DESCRIPTION
pix.size was passed to playdate.graphics.drawPixel, but it looks like that call should only take an x and y position.

<img width="624" alt="image" src="https://github.com/user-attachments/assets/79c21e0c-4001-4e43-aef9-6f92e43e187e" />


[https://sdk.play.date/2.6.2/Inside%20Playdate.html#f-graphics.drawPixel](https://sdk.play.date/2.6.2/Inside%20Playdate.html#f-graphics.drawPixel)